### PR TITLE
Smart screen share cropping

### DIFF
--- a/src/components/Canvas/ComponentForSharing/ComponentForSharing.tsx
+++ b/src/components/Canvas/ComponentForSharing/ComponentForSharing.tsx
@@ -18,5 +18,11 @@ export default function ComponentForSharing() {
 
   makeFontSize(100, 6);
 
-  return <div ref={myRef} style={{ background: 'white', width: '65vw', height: '100vh', overflowY: 'scroll' }}></div>;
+  return (
+    <div
+      id="slideShare"
+      ref={myRef}
+      style={{ background: 'white', width: '65vw', height: '100vh', overflowY: 'scroll' }}
+    ></div>
+  );
 }

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { LogLevels, Track, Room } from 'twilio-video';
+import { LocalVideoTrack, LogLevels, Track, Room } from 'twilio-video';
 import { VideoRoomMonitor } from '@twilio/video-room-monitor';
 
 interface MediaStreamTrackPublishOptions {
@@ -28,73 +28,6 @@ function testCropp(screenTrack: any, mediaStream: any) {
   }
 }
 
-function getCanvasMedia(stream: MediaStream) {
-  const fpsInterval = 1000 / 24;
-  let lastRenderTime = 0;
-
-  const myCanvas = document.getElementById('myCanvas') as HTMLCanvasElement;
-  const ctx = myCanvas.getContext('2d') as CanvasRenderingContext2D;
-
-  const myImage = document.getElementById('myImage') as HTMLVideoElement;
-  const myVideo = document.getElementById('myVideo') as HTMLVideoElement;
-
-  const imgOffset = myImage.getBoundingClientRect();
-  const imgPercent = imgOffset.width / imgOffset.height;
-  myVideo.srcObject = stream;
-  myVideo.play();
-  myCanvas.height = myCanvas.width / imgPercent;
-
-  // @ts-ignore
-  const streamCanvas = myCanvas.captureStream();
-
-  const top = window.screenY + window.outerHeight - window.innerHeight + imgOffset.top;
-  const left = window.screenX + imgOffset.left;
-  const width = imgOffset.width;
-  const height = imgOffset.height;
-
-  const flag: string = 'requestAnimationFrame'; // 'setInterval', 'requestAnimationFrame', 'ontimeupdate', 'none'
-  // ngrok http 3000 --host-header="localhost:3000"
-
-  switch (flag) {
-    case 'ontimeupdate':
-      console.log('%c ontimeupdate ===>', 'background-color: grey');
-      myVideo.ontimeupdate = ev => {
-        // console.log(Date.now());
-        // ctx.drawImage(myVideo, 0, 0, myCanvas.width, myCanvas.height);
-        ctx.drawImage(myVideo, left, top, width, height, 0, 0, myCanvas.width, myCanvas.height);
-      };
-      break;
-    case 'setInterval':
-      console.log('%c setInterval ===>', 'background-color: grey');
-      setInterval(() => {
-        console.log(Date.now());
-        // ctx.drawImage(myVideo, 0, 0, myCanvas.width, myCanvas.height);
-        ctx.drawImage(myVideo, left, top, width, height, 0, 0, myCanvas.width, myCanvas.height);
-      }, 100);
-      break;
-    case 'requestAnimationFrame':
-      console.log('%c requestAnimationFrame ===>', 'background-color: grey');
-      window.requestAnimationFrame(go);
-      break;
-    default:
-      console.log('NONE');
-      break;
-  }
-
-  function go(currentTime: number) {
-    const deltaTime = currentTime - lastRenderTime;
-
-    if (deltaTime >= fpsInterval) {
-      ctx.drawImage(myVideo, left, top, width, height, 0, 0, myCanvas.width, myCanvas.height);
-      lastRenderTime = currentTime - (deltaTime % fpsInterval);
-    }
-    window.requestAnimationFrame(go);
-    // ctx.drawImage(myVideo, left, top, width, height, 0, 0, myCanvas.width, myCanvas.height);
-  }
-
-  return { streamCanvas };
-}
-
 export default function useScreenShareToggle(room: Room | null, onError: any) {
   const [isSharing, setIsSharing] = useState(false);
   const stopScreenShareRef = useRef<() => void>(null!);
@@ -103,16 +36,209 @@ export default function useScreenShareToggle(room: Room | null, onError: any) {
     navigator.mediaDevices
       .getDisplayMedia({
         audio: false,
-        video: true,
+        video: { frameRate: { max: 24 } },
       })
       .then(stream => {
         const customScreenSharing = localStorage.getItem('customScreenSharing');
+        const myImage = document.getElementById('slideShare') as HTMLElement;
+        const { innerHeight, outerHeight } = window;
+        const slireShareRect = myImage.getBoundingClientRect();
+        const { left, top, height } = slireShareRect;
+        const width = height + outerHeight - innerHeight;
 
+        let deviceId: any;
         let track: any;
+
         if (customScreenSharing === 'true') {
-          const { streamCanvas } = getCanvasMedia(stream);
-          track = streamCanvas.getTracks()[0];
-          testCropp(null, streamCanvas);
+          // @ts-ignore
+          const canvas =
+            typeof OffscreenCanvas !== 'undefined'
+              ? // @ts-ignore
+                new OffscreenCanvas(128, 128)
+              : document.createElement('canvas');
+
+          const context = canvas.getContext('2d', {
+            willReadFrequently: true,
+          }) as CanvasRenderingContext2D;
+
+          canvas.width = 128;
+          canvas.height = 128;
+
+          // NOTE(mmalavalli): Most modern versions of Chrome support the Insertable Streams API, which is a much more efficient
+          // way of processing individual video frames. So, we use this API to crop the screen share video frames.
+          // @ts-ignore
+          if (
+            typeof MediaStreamTrackGenerator !== 'undefined' &&
+            typeof MediaStreamTrackProcessor !== 'undefined' &&
+            typeof TransformStream !== 'undefined'
+          ) {
+            const [origScreenTrack] = stream.getVideoTracks();
+            // @ts-ignore
+            const generator = new MediaStreamTrackGenerator({ kind: 'video' });
+            // @ts-ignore
+            const processor = new MediaStreamTrackProcessor({ track: origScreenTrack });
+
+            processor.readable
+              .pipeThrough(
+                new TransformStream({
+                  // NOTE(mmalavalli): This function ensures that only those cropped video frames that
+                  // record any movement on the screen are passed to the MediaStreamTrack.
+                  // @ts-ignore
+                  transform(frame: VideoFrame, controller: any) {
+                    context.globalCompositeOperation = 'difference';
+                    context.drawImage(
+                      frame,
+                      left,
+                      top,
+                      width * devicePixelRatio,
+                      height * devicePixelRatio,
+                      0,
+                      0,
+                      canvas.width,
+                      canvas.height
+                    );
+
+                    const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+
+                    let motionScore = 0;
+                    for (let i = 0; i < data.length && motionScore < 5; i += 4) {
+                      motionScore += Number(data[i] || data[i + 1] || data[i + 2]);
+                    }
+
+                    context.globalCompositeOperation = 'copy';
+                    context.drawImage(
+                      frame,
+                      left,
+                      top,
+                      width * devicePixelRatio,
+                      height * devicePixelRatio,
+                      0,
+                      0,
+                      canvas.width,
+                      canvas.height
+                    );
+
+                    if (motionScore >= 5) {
+                      // @ts-ignore
+                      controller.enqueue(
+                        new VideoFrame(frame, {
+                          visibleRect: {
+                            x: left,
+                            y: top,
+                            width: width * devicePixelRatio,
+                            height: height * devicePixelRatio,
+                          },
+                        })
+                      );
+                    }
+
+                    frame.close();
+                  },
+                })
+              )
+              .pipeTo(generator.writable);
+
+            const newStream = new MediaStream([generator]);
+            track = newStream.getVideoTracks()[0];
+            deviceId = track.getSettings().deviceId;
+
+            testCropp(null, newStream);
+          } else {
+            // NOTE(mmalavalli): For browsers that do not support the Insertable Streams API, we add a
+            // VideoProcessor to the screen share track which crops and passes through only those video
+            // frames that record any movement on the screen.
+            track = new LocalVideoTrack(stream.getTracks()[0], { name: 'screen' });
+            track.addProcessor({
+              processFrame(input: any, output: any) {
+                context.globalCompositeOperation = 'difference';
+                context.drawImage(
+                  input,
+                  left,
+                  top,
+                  width * devicePixelRatio,
+                  height * devicePixelRatio,
+                  0,
+                  0,
+                  canvas.width,
+                  canvas.height
+                );
+
+                const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+
+                let motionScore = 0;
+                for (let i = 0; i < data.length && motionScore < 5; i += 4) {
+                  motionScore += Number(data[i] || data[i + 1] || data[i + 2]);
+                }
+
+                context.globalCompositeOperation = 'copy';
+                context.drawImage(
+                  input,
+                  left,
+                  top,
+                  width * devicePixelRatio,
+                  height * devicePixelRatio,
+                  0,
+                  0,
+                  canvas.width,
+                  canvas.height
+                );
+
+                if (motionScore >= 5) {
+                  output
+                    .getContext('2d')
+                    .drawImage(
+                      input,
+                      left,
+                      top,
+                      width * devicePixelRatio,
+                      height * devicePixelRatio,
+                      (output.width - width * devicePixelRatio) >> 1,
+                      (output.height - height * devicePixelRatio) >> 1,
+                      width * devicePixelRatio,
+                      height * devicePixelRatio
+                    );
+                }
+              },
+            });
+            deviceId = track.processedTrack.getSettings().deviceId;
+            testCropp(null, new MediaStream([track.processedTrack]));
+          }
+
+          // NOTE(mmalavalli): Since we are publishing a processed version of the screen share track,
+          // this makes sure that the adaptive simulcast feature performs temporal degradation instead
+          // of spatial degradation.
+          // @ts-ignore
+          const pcv2 = [...room!._signaling._peerConnectionManager._peerConnections.values()][0];
+          const updateEncodings = pcv2._updateEncodings;
+          pcv2._updateEncodings = function _updateEncodings(
+            track: MediaStreamTrack,
+            encodings: RTCRtpEncodingParameters[],
+            trackReplaced: boolean
+          ) {
+            updateEncodings.apply(pcv2, [track, encodings, trackReplaced]);
+            if (track.getSettings().deviceId === deviceId) {
+              const screenShareActiveLayerConfig = [
+                { maxFramerate: 5, scaleResolutionDownBy: 1 },
+                { scaleResolutionDownBy: 1 },
+              ];
+              encodings.forEach((encoding, i) => {
+                const activeLayerConfig = screenShareActiveLayerConfig[i];
+                if (activeLayerConfig) {
+                  encoding.scaleResolutionDownBy = activeLayerConfig.scaleResolutionDownBy;
+                  if ('maxFramerate' in activeLayerConfig) {
+                    // @ts-ignore
+                    encoding.maxFramerate = activeLayerConfig.maxFramerate;
+                  }
+                  if (trackReplaced) {
+                    delete encoding.active;
+                  }
+                } else {
+                  encoding.active = false;
+                  delete encoding.scaleResolutionDownBy;
+                }
+              });
+            }
+          };
         } else {
           console.log('NO Cropping');
           track = stream.getTracks()[0];

--- a/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
+++ b/src/components/VideoProvider/useScreenShareToggle/useScreenShareToggle.tsx
@@ -66,9 +66,10 @@ export default function useScreenShareToggle(room: Room | null, onError: any) {
 
           // NOTE(mmalavalli): Most modern versions of Chrome support the Insertable Streams API, which is a much more efficient
           // way of processing individual video frames. So, we use this API to crop the screen share video frames.
-          // @ts-ignore
           if (
+            // @ts-ignore
             typeof MediaStreamTrackGenerator !== 'undefined' &&
+            // @ts-ignore
             typeof MediaStreamTrackProcessor !== 'undefined' &&
             typeof TransformStream !== 'undefined'
           ) {


### PR DESCRIPTION
This pull request implements a screen share cropping feature that accomplishes the following goals:
1. An efficient way of cropping and passing through only those screen frames that record any movement on the screen.
2. Ensure that the adaptive simulcast feature of the video sdk treats the transformed track as a screen share track by degrading temporally instead of spatially.

Point no. 2 addresses the video quality issue, because the transformed stream is not treated as a screen share track by the sdk and therefore degrades the track based on resolution. So, whenever there is network congestion or bandwidth issues on the remote participant, the lower resolution stream is received.